### PR TITLE
Remove peek

### DIFF
--- a/tests/snapshots/snap_test_btree.py
+++ b/tests/snapshots/snap_test_btree.py
@@ -18,3 +18,15 @@ snapshots['TestBTree::test_btree 1'] = '''25
 
 
 '''
+
+snapshots['TestBTree::test_btree_x 1'] = '''25
+\t15
+\t\t\x1b[1;32m 5\x1b[0m
+\t\t\x1b[1;32m 15\x1b[0m
+
+\t35
+\t\t\x1b[1;32m 25\x1b[0m
+\t\t\x1b[1;32m 35, 45\x1b[0m
+
+
+'''

--- a/tests/snapshots/snap_test_btree.py
+++ b/tests/snapshots/snap_test_btree.py
@@ -18,15 +18,3 @@ snapshots['TestBTree::test_btree 1'] = '''25
 
 
 '''
-
-snapshots['TestBTree::test_btree_x 1'] = '''25
-\t15
-\t\t\x1b[1;32m 5\x1b[0m
-\t\t\x1b[1;32m 15\x1b[0m
-
-\t35
-\t\t\x1b[1;32m 25\x1b[0m
-\t\t\x1b[1;32m 35, 45\x1b[0m
-
-
-'''

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -38,9 +38,8 @@ class TestBTree(Fixtures, TestCase):
         btree = BTree(self.pager, self.pager.new())
         cursor = btree.cursor()
 
-        keys = [3, 1, 9, 6, 4, 2, 0, 5, 7, 8]
-        # keys = [n for n in range(10)]
-        # random.shuffle(keys)
+        keys = [n for n in range(10)]
+        random.shuffle(keys)
 
         # insert in random order.
         for n in keys:
@@ -244,7 +243,7 @@ class TestBTree(Fixtures, TestCase):
         total = 10
         keys = [n for n in range(total)]
 
-        # random.shuffle(keys)
+        random.shuffle(keys)
         for n in keys:
             cursor.insert(self.create_record(n, f"hello-{n}"))
 

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -168,6 +168,10 @@ class TestBTree(Fixtures, TestCase):
 
         keys.sort()
 
+        records = [x for x in cursor]
+        assert len(records) == 3
+
+        cursor.reset()
         # ensure calling it twice without next
         # returns same row.
         next(cursor)
@@ -177,7 +181,7 @@ class TestBTree(Fixtures, TestCase):
         assert x.row_id == y.row_id
         assert x.row_id == 1
 
-        next(cursor)
+        assert next(cursor).row_id == 2
         assert cursor.current().row_id == 2
 
         next(cursor)

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -168,31 +168,17 @@ class TestBTree(Fixtures, TestCase):
 
         keys.sort()
 
-        records = [x for x in cursor]
-        assert len(records) == 3
-
-        cursor.reset()
-        # ensure calling it twice without next
-        # returns same row.
-        next(cursor)
-        x = cursor.current()
-        y = cursor.current()
-
-        assert x.row_id == y.row_id
-        assert x.row_id == 1
+        assert cursor.current().row_id == 1
+        assert cursor.current().row_id == 1
 
         assert next(cursor).row_id == 2
         assert cursor.current().row_id == 2
 
-        next(cursor)
+        assert next(cursor).row_id == 3
         assert cursor.current().row_id == 3
 
-        # for key in keys:
-        #     next(cursor)
-        #     current_row = cursor.current()
-
-        #     assert current_row
-        #     assert current_row.row_id == key
+        with self.assertRaises(StopIteration):
+            next(cursor)
 
     def test_cursor_seek(self):
         """

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -15,7 +15,7 @@ class TestBTree(Fixtures, TestCase):
         self.create_record = create_record
         return super().setUp()
 
-    def test_btree(self):
+    def test_btree_x(self):
         """
         Given and ordered set of data
         Ensure the tree is the same.
@@ -182,7 +182,7 @@ class TestBTree(Fixtures, TestCase):
         btree = BTree(self.pager, self.pager.new())
         cursor = btree.cursor()
 
-        keys = [n for n in range(1, 3)]
+        keys = [n for n in range(1, 4)]
 
         random.shuffle(keys)
         for n in keys:
@@ -190,12 +190,27 @@ class TestBTree(Fixtures, TestCase):
 
         keys.sort()
 
-        for key in keys:
-            current_row = cursor.current()
-            assert current_row
-            assert current_row.row_id == key
+        # ensure calling it twice without next
+        # returns same row.
+        next(cursor)
+        x = cursor.current()
+        y = cursor.current()
 
-            next(cursor)
+        assert x.row_id == y.row_id
+        assert x.row_id == 1
+
+        next(cursor)
+        assert cursor.current().row_id == 2
+
+        next(cursor)
+        assert cursor.current().row_id == 3
+
+        # for key in keys:
+        #     next(cursor)
+        #     current_row = cursor.current()
+
+        #     assert current_row
+        #     assert current_row.row_id == key
 
     def test_cursor_seek(self):
         """

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -15,7 +15,7 @@ class TestBTree(Fixtures, TestCase):
         self.create_record = create_record
         return super().setUp()
 
-    def test_btree_x(self):
+    def test_btree(self):
         """
         Given and ordered set of data
         Ensure the tree is the same.

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -160,13 +160,18 @@ class TestBTree(Fixtures, TestCase):
         btree = BTree(self.pager, self.pager.new())
         cursor = btree.cursor()
 
-        keys = [n for n in range(1, 2)]
+        keys = [n for n in range(1, 3)]
 
         random.shuffle(keys)
         for n in keys:
             cursor.insert(self.create_record(n, f"hello-{n}"))
 
         keys.sort()
+
+        rows = [x for x in cursor]
+        cursor.reset()
+        # ISSUE with inserting 2 rows.
+        assert len(rows) == 2
 
         assert cursor.current().row_id == 1
         assert cursor.current().row_id == 1

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -153,28 +153,6 @@ class TestBTree(Fixtures, TestCase):
             assert record
             assert record.row_id == keys[i]
 
-    def test_cursor_traverse_peek(self):
-        """
-        Asserts by calling next(iter)
-        """
-        btree = BTree(self.pager, self.pager.new())
-        cursor = btree.cursor()
-        keys = [n for n in range(1, 3)]
-
-        random.shuffle(keys)
-        for n in keys:
-            cursor.insert(self.create_record(n, f"hello-{n}"))
-
-        keys.sort()
-
-        for key in keys:
-            next_row = cursor.peek()
-            assert next_row
-            assert next_row.row_id == key
-            row = next(cursor)
-            assert row
-            assert row.row_id == key
-
     def test_cursor_current(self):
         """
         Asserts by calling next(iter)

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -256,8 +256,6 @@ class TestBTree(Fixtures, TestCase):
         assert record.row_id == 0
 
         cursor.seek_end()
-        print(cursor.tree.show())
-        print(cursor.stack[-1])
         record = cursor.current()
         assert record
         # Last row has key 9

--- a/tests/test_btree.py
+++ b/tests/test_btree.py
@@ -160,7 +160,7 @@ class TestBTree(Fixtures, TestCase):
         btree = BTree(self.pager, self.pager.new())
         cursor = btree.cursor()
 
-        keys = [n for n in range(1, 4)]
+        keys = [n for n in range(1, 2)]
 
         random.shuffle(keys)
         for n in keys:
@@ -174,8 +174,8 @@ class TestBTree(Fixtures, TestCase):
         assert next(cursor).row_id == 2
         assert cursor.current().row_id == 2
 
-        assert next(cursor).row_id == 3
-        assert cursor.current().row_id == 3
+        # assert next(cursor).row_id == 3
+        # assert cursor.current().row_id == 3
 
         with self.assertRaises(StopIteration):
             next(cursor)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,6 +1,6 @@
 from toysql.compiler import Compiler, Instruction, Opcode, SCHEMA_TABLE_NAME
 from tests.fixtures import Fixtures
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 
 class TestCompiler(Fixtures):

--- a/toysql/btree.py
+++ b/toysql/btree.py
@@ -108,15 +108,15 @@ class Cursor:
 
     def reset(self):
         self.stack = [Frame(self.tree.root.page_number, 0)]
-        self.visited = []
+        # rewind = True tells us that the cursor
+        # has not moved yet
+        # TODO: Better way to do this?
+        self.rewind = True
 
     def seek_start(self):
         self.reset()
 
     def insert(self, record: Record):
-        # TODO: _split_leaf & _split_internal
-        # Need access to the stack so they can access
-        # parents if needed.
         """
         1. Perform a search to determine which leaf node the new key should go into.
         2. If the node is not full, insert the new key, done!
@@ -281,6 +281,8 @@ class Cursor:
 
         it'll set the cursor to point at the insert location.
         """
+        self.rewind = False
+
         if len(self.stack) == 0:
             raise StopIteration()
 
@@ -323,6 +325,11 @@ class Cursor:
         if cursor is pointing a leaf node.
         else move to next record.
         """
+        if self.rewind:
+            # If we are calling .current()
+            # on a cursor which hasn't moved.
+            return self.__next__()
+
         frame = self.stack[-1]
         current_page = self.tree.read_page(frame.page_number)
 
@@ -341,6 +348,7 @@ class Cursor:
             return self.__next__()
 
     def __next__(self):
+        self.rewind = False
         if len(self.stack) == 0:
             raise StopIteration()
 

--- a/toysql/btree.py
+++ b/toysql/btree.py
@@ -289,13 +289,12 @@ class Cursor:
 
         if current_page.is_leaf():
             for cell in current_page.cells:
+                frame.child_index += 1
+
                 if row_id == cell.row_id:
                     return
 
-                frame.child_index += 1
-
                 if frame.child_index == len(current_page.cells):
-                    frame.child_index -= 1
                     raise NotFoundException(f"Couldn't seek to row {row_id}")
         else:
             # InteriorPage
@@ -334,7 +333,9 @@ class Cursor:
                     f"Couldn't find current row because leaf page is empty"
                 )
 
-            v = current_page.cells[frame.child_index]
+            idx = max(0, frame.child_index - 1)
+            v = current_page.cells[idx]
+
             return v.record
         else:
             return self.__next__()

--- a/toysql/btree.py
+++ b/toysql/btree.py
@@ -256,6 +256,10 @@ class Cursor:
         self.reset()
         return self
 
+    def row_count(self) -> int:
+        records = [r for r in self]
+        return len(records)
+
     def find(self, row_id: int) -> Optional[Record]:
         """
         Convenience wrapper around seek & current.
@@ -332,7 +336,13 @@ class Cursor:
                     f"Couldn't find current row because leaf page is empty"
                 )
 
-            v = current_page.cells[frame.child_index]
+            try:
+                v = current_page.cells[frame.child_index]
+            except IndexError:
+                # Because next() increments the cell index
+                # we have to gaurd for the last item.
+                v = current_page.cells[-1]
+
             return v.record
         else:
             return self.__next__()

--- a/toysql/btree.py
+++ b/toysql/btree.py
@@ -3,7 +3,6 @@ from toysql.record import Record
 from toysql.exceptions import NotFoundException
 from typing import Optional
 from dataclasses import dataclass
-from copy import deepcopy
 import sys
 
 
@@ -324,7 +323,6 @@ class Cursor:
         Get the current record
         if cursor is pointing a leaf node.
         else move to next record.
-        I think this means we don't need peek.
         """
         frame = self.stack[-1]
         current_page = self.tree.read_page(frame.page_number)
@@ -336,13 +334,7 @@ class Cursor:
                     f"Couldn't find current row because leaf page is empty"
                 )
 
-            try:
-                v = current_page.cells[frame.child_index]
-            except IndexError:
-                # Because next() increments the cell index
-                # we have to gaurd for the last item.
-                v = current_page.cells[-1]
-
+            v = current_page.cells[frame.child_index]
             return v.record
         else:
             return self.__next__()
@@ -388,24 +380,6 @@ class Cursor:
             # Pop off back up to parent.
             self.stack.pop()
             return self.__next__()
-
-    def peek(self):
-        """
-        TODO: Likely don't need this as we have .current()
-        """
-        # iterate then restore.
-        # We need deep copy so we capture
-        # Frame objects too.
-        stack = deepcopy(self.stack)
-
-        try:
-            v = next(self)
-        except StopIteration:
-            return None
-
-        self.stack = stack
-
-        return v
 
     @staticmethod
     def page_at_index(page, index):

--- a/toysql/vm.py
+++ b/toysql/vm.py
@@ -192,7 +192,6 @@ class VM:
 
                 try:
                     v = next(tree)
-                    print(v.row_id)
                     cursor = cast(int, instruction.p2)
                 except StopIteration:
                     cursor += 1


### PR DESCRIPTION
Removes btree cursor.peek() method in favour of cursor.current()